### PR TITLE
Improved handling of empty subbands 

### DIFF
--- a/lightcurve_pipeline/lightcurve-cabs.yml
+++ b/lightcurve_pipeline/lightcurve-cabs.yml
@@ -15,3 +15,16 @@ cabs:
       args:
         dtype: List[Any]
 
+  add-imaging-columns:
+    flavour: python-code
+    command: |
+      import casacore.tables as pt
+      pt.addImagingColumns(ms_path)
+    inputs:
+      ms-path:
+        info: Path to the measurement set.
+        dtype: MS
+        policies:
+          positional: true
+        must_exist: true
+        writable: true

--- a/lightcurve_pipeline/lightcurve-pipeline.yml
+++ b/lightcurve_pipeline/lightcurve-pipeline.yml
@@ -122,6 +122,15 @@ lightcurve-pipeline:
       params:
         ms: =recipe.ms-path
 
+    add-columns-1:
+      info: |
+        Use python-casacore to add all the imaging columns to the measurement
+        set - this ensures that they are added with a TiledStorageManager and
+        initialised to zero.
+      cab: add-imaging-columns
+      params:
+        ms-path: =recipe.ms-path
+
     image-1:
       info: |
         Image and deconvolve the data using wsclean. This initial round of

--- a/lightcurve_pipeline/lightcurve-pipeline.yml
+++ b/lightcurve_pipeline/lightcurve-pipeline.yml
@@ -165,22 +165,23 @@ lightcurve-pipeline:
         size: =recipe.size
         abs-threshold: =recipe.abs-threshold
         fits-mask: '{steps.mask-1.outfile}'
+        no-update-model-required: false
       skip_if_outputs: fresh
 
-    predict-1:
-      info: |
-        Use wsclean to write the visibilities associated with the model to the
-        MODEL_DATA column. This is done as a separate step to make it possible
-        to inspect the images before updating the MODEL_DATA column.
-      cab: wsclean
-      params:
-        ms: =recipe.ms-path
-        temp-dir: =recipe.tempdir-path
-        prefix: '{steps.image-2.prefix}'
-        nchan: '{steps.image-2.nchan}'
-        size: =recipe.size
-        scale: =recipe.scale
-        predict: true
+    # predict-1:
+    #   info: |
+    #     Use wsclean to write the visibilities associated with the model to the
+    #     MODEL_DATA column. This is done as a separate step to make it possible
+    #     to inspect the images before updating the MODEL_DATA column.
+    #   cab: wsclean
+    #   params:
+    #     ms: =recipe.ms-path
+    #     temp-dir: =recipe.tempdir-path
+    #     prefix: '{steps.image-2.prefix}'
+    #     nchan: '{steps.image-2.nchan}'
+    #     size: =recipe.size
+    #     scale: =recipe.scale
+    #     predict: true
 
     selfcal-1:
       info: |
@@ -231,22 +232,23 @@ lightcurve-pipeline:
         size: =recipe.size
         abs-threshold: =recipe.abs-threshold
         fits-mask: '{steps.mask-1.outfile}'  # Should we make a new mask?
+        no-update-model-required: false
       skip_if_outputs: fresh
 
-    predict-2:
-      info: |
-        Use wsclean to write the visibilities associated with the model to the
-        MODEL_DATA column. This is done as a separate step to make it possible
-        to inspect the images before updating the MODEL_DATA column.
-      cab: wsclean
-      params:
-        ms: =recipe.ms-path
-        temp-dir: =recipe.tempdir-path
-        prefix: '{steps.image-3.prefix}'
-        nchan: '{steps.image-3.nchan}'
-        size: =recipe.size
-        scale: =recipe.scale
-        predict: true
+    # predict-2:
+    #   info: |
+    #     Use wsclean to write the visibilities associated with the model to the
+    #     MODEL_DATA column. This is done as a separate step to make it possible
+    #     to inspect the images before updating the MODEL_DATA column.
+    #   cab: wsclean
+    #   params:
+    #     ms: =recipe.ms-path
+    #     temp-dir: =recipe.tempdir-path
+    #     prefix: '{steps.image-3.prefix}'
+    #     nchan: '{steps.image-3.nchan}'
+    #     size: =recipe.size
+    #     scale: =recipe.scale
+    #     predict: true
 
     subtract-model:  # Replace with a second selfcal step?
       info: |


### PR DESCRIPTION
This PR removes the separate predict steps in favour of letting `wsclean` predict during/after imaging. This is an imperfect but simple solution to the problem of empty sub-bands. If this proves inadequate, it is possible to a create cab to handle zeroing the NaN model images but I would prefer to avoid a bespoke solution. Additionally, in the empty subband case, `wsclean` may only partially write the MODEL_DATA column. This leads to performance degradation. This PR also adds a simple cab to invoke `add_imaging_columns` from `python-casacore`. This may be slightly overkill (we are unlikely to need `IMAGING_WEIGHT`) but it should be highly compressed provided it is never written to. If this becomes a problem, I will write a custom cab to add only the MODEL_DATA and CORRECTED_DATA.