### PR TITLE
Fix/improve UHF flagging defaults.

### DIFF
--- a/lightcurve_pipeline/flagging/meerkat_1k_basic.yml
+++ b/lightcurve_pipeline/flagging/meerkat_1k_basic.yml
@@ -22,7 +22,7 @@ meerkat-target-flagging:
           *:1010~1150MHz
 
         CAL_1GC_BL_FLAG_UVRANGE: '<600'
-        CAL_1GC_BL_FREQS: ''
+        CAL_1GC_BL_FREQS: null
 
       L:
         CAL_1GC_FREQRANGE: '*:1300~1400MHz'
@@ -155,6 +155,7 @@ meerkat-target-flagging:
         spw: =recipe.CAL_1GC_BL_FREQS
         mode: 'manual'
         uvrange: =recipe.CAL_1GC_BL_FLAG_UVRANGE
+      skip: =not ifset(recipe.CAL_1GC_BL_FREQS)
 
     flag-autocorrelations:
       info: Flag all autocorrelations.

--- a/lightcurve_pipeline/flagging/meerkat_1k_basic.yml
+++ b/lightcurve_pipeline/flagging/meerkat_1k_basic.yml
@@ -18,11 +18,12 @@ meerkat-target-flagging:
         CAL_1GC_UVRANGE: '>150m'
 
         CAL_1GC_BAD_FREQS : >-
-          *:540~570MHz,
-          *:1010~1150MHz
+          *:540~580MHz,
+          *:935~960MHz,
+          *:1050~1150MHz
 
         CAL_1GC_BL_FLAG_UVRANGE: '<600'
-        CAL_1GC_BL_FREQS: null
+        CAL_1GC_BL_FREQS: ''
 
       L:
         CAL_1GC_FREQRANGE: '*:1300~1400MHz'
@@ -155,7 +156,7 @@ meerkat-target-flagging:
         spw: =recipe.CAL_1GC_BL_FREQS
         mode: 'manual'
         uvrange: =recipe.CAL_1GC_BL_FLAG_UVRANGE
-      skip: =not ifset(recipe.CAL_1GC_BL_FREQS)
+      skip: =IF(recipe.CAL_1GC_BL_FREQS == '', true, false)
 
     flag-autocorrelations:
       info: Flag all autocorrelations.


### PR DESCRIPTION
Add an extra band to the UHF default RFI settings. Skip flagging below a given UV cutoff when no specific channels are specified; CASA otherwise flags all channels which is excessive.